### PR TITLE
Adds a conditional attribute check for run_content

### DIFF
--- a/libraries/resource.rb
+++ b/libraries/resource.rb
@@ -15,13 +15,15 @@ class Chef
       def allow(val)
         node.run_state[:dpkg_autostart_disabled] ||= []
         node.run_state[:dpkg_autostart_disabled].push(name) unless val
-        begin
-          node.run_context.resource_collection.lookup('dpkg_autostart[bin_file]')
-          true
-        rescue Chef::Exceptions::ResourceNotFound
-          bin = Chef::Resource::DpkgAutostart.new('bin_file', node.run_context)
-          bin.action :create
-          node.run_context.resource_collection.all_resources.unshift(bin)
+        if node.attribute?("run_context")
+          begin
+            node.run_context.resource_collection.lookup('dpkg_autostart[bin_file]')
+            true
+          rescue Chef::Exceptions::ResourceNotFound
+            bin = Chef::Resource::DpkgAutostart.new('bin_file', node.run_context)
+            bin.action :create
+            node.run_context.resource_collection.all_resources.unshift(bin)
+          end
         end
       end
     end


### PR DESCRIPTION
Ok, some caveats:
1. I don't speak ruby.
2. I've spent a total of two days with chef-solo.

That said, as issue #1 mentions, this cookbook is broken in Chef 10.  So, this PR is a fix.  I worry it's actually a fix that disables much of the functionality of `dpkg_autostart`, but I wasn't able to get `run_context` set via `initialize` or `attributes/default.rb`.  This change does at least allow the package to run, and in my case, let me get on with installing the postgis cookbook that depended on this recipe.  

Hopefully this is of some use!

Thanks,
Steven
