### PR TITLE
support upstart(-only) services

### DIFF
--- a/templates/default/policy-rc.d.erb
+++ b/templates/default/policy-rc.d.erb
@@ -62,7 +62,7 @@ SRV_ARGS=$*
 SRV_DISABLED=0
 ACT_DISABLED=0
 
-if [ ! -f "/etc/init.d/${SRV_NAME}" ]; then
+if [ ! -x "/etc/init.d/${SRV_NAME}" && ! -f "/etc/init/${SRV_NAME}.conf" ]; then
     exit 100
 fi
 


### PR DESCRIPTION
I just ran into this when trying your lxc cookbook on ubuntu saucy. lxc and several other packages are now upstart-only, they don't bring a file in /etc/init.d anymore. Also, checking with -f does not catch symlinks to upstart.
