### PR TITLE
Restore Chef Infra Client < 16 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the dpkg_autostart cookbook.
 
+## UNRELEASED
+
+- Restore Chef Infra Client < 16 compatibility
+
 ## v0.3.1 (2020-06-02)
 
 - resolved cookstyle error: libraries/resource.rb:8:7 warning: `ChefDeprecations/ResourceUsesOnlyResourceName`

--- a/libraries/resource.rb
+++ b/libraries/resource.rb
@@ -5,6 +5,7 @@ class Chef
     class DpkgAutostart < Chef::Resource
       allowed_actions [:nothing, :create]
 
+      resource_name :dpkg_autostart
       provides :dpkg_autostart
 
       default_action :nothing


### PR DESCRIPTION
Chef Infra Client 16 needs provides and Chef Infra Client < 16 needs resource_name here. If we support both then we need both.

Signed-off-by: Tim Smith <tsmith@chef.io>