### PR TITLE
bugfix: Refactor provider to revert to method syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the dpkg_autostart cookbook.
 
+## 0.4.2 (2020-10-23)
+
+- Fix regression introduced in 0.4.1, of undefined method `action` being received
+
 ## 0.4.1 (2020-09-16)
 
 - resolved cookstyle error: libraries/provider.rb:13:7 refactor: `ChefModernize/ActionMethodInResource`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the dpkg_autostart cookbook.
 
-## 0.4.2 (2020-10-23)
+## Unreleased
 
 - Fix regression introduced in 0.4.1, of undefined method `action` being received
 

--- a/libraries/provider.rb
+++ b/libraries/provider.rb
@@ -10,11 +10,11 @@ class Chef
       def load_current_resource
       end
 
-      action :run do
+      def action_run
         Chef::Log.debug 'DpkgAutostart: Compat method. Action does nothing.'
       end
 
-      action :create do
+      def action_create
         template = Chef::Resource::Template.new('dpkg_autostart_file', run_context)
         template.cookbook 'dpkg_autostart'
         template.source 'policy-rc.d.erb'


### PR DESCRIPTION
Fixes regression introduced in v0.4.1

# Description

Reverts back to use method syntax to define actions in resources

## Issues Resolved

List any existing issues this PR resolves https://github.com/sous-chefs/dpkg_autostart/issues/21

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
