### PR TITLE
fix: pass Slack secrets to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}
       supermarket_key: ${{ secrets.CHEF_SUPERMARKET_KEY }}
+      slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}


### PR DESCRIPTION
## Summary
Follow up the merged migration work by passing the required Slack secrets into the reusable release workflow.

## Testing
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec spec/unit/resources/dpkg_autostart_spec.rb