### PR TITLE
feat!: document custom resource migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ be applied. Instead of disabling all services from auto starting on installation
 as the `dpkg_deb_unautostart` cookbook does, lets allow specific services
 to be targeted.
 
+## Breaking change for upgrades
+
+Upgrading from older cookbook releases that used `recipes/default.rb` and
+`attributes/default.rb` is a breaking change. Those recipe and attribute
+entry points were removed when the cookbook moved to the `dpkg_autostart`
+custom resource.
+
+Before upgrading, replace any `include_recipe 'dpkg_autostart::default'`
+usage and any `node['dpkg_autostart']` attribute configuration with one
+`dpkg_autostart` resource per service. See [migration.md](migration.md).
+
 ## Usage
 
 Include the cookbook as a dependency in your metadata:

--- a/migration.md
+++ b/migration.md
@@ -2,6 +2,18 @@
 
 This cookbook migrated from attribute-driven recipe setup to a single custom resource.
 
+## Breaking change for operators upgrading older releases
+
+This is a breaking change for any wrapper cookbook, role, or policy that
+still includes `dpkg_autostart::default` or sets `node['dpkg_autostart']`
+attributes. The recipe and attribute interfaces were removed, so existing
+attribute-driven configuration must be rewritten to use `dpkg_autostart`
+resources directly before you upgrade.
+
+If you upgrade without making that change, the old recipe include and
+attribute configuration will no longer manage `policy-rc.d` for your
+services.
+
 ## What changed
 
 * `attributes/default.rb` was removed.


### PR DESCRIPTION
## Summary
- add explicit breaking-change guidance in README for operators upgrading older releases
- strengthen migration.md to state that recipe and attribute-based configuration must be rewritten to the custom resource before upgrade

## Testing
- not run (docs-only change)
