### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Provides the dpkg_autostart resource for suppressing service starts during dpkg operations.
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Package Availability
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'dpkg_autostart'
+
+run_list 'test::default'
+
+cookbook 'dpkg_autostart', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress